### PR TITLE
removed bundle.js script tag from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
-        <script defer src="bundle.js"></script>
+        <!-- <script defer src="bundle.js"></script> -->
         <meta charset="UTF-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">


### PR DESCRIPTION
Removed script tag for bundle.js in index.html.

- The script tag is automatically injected into the html file in the build folder for both dev and production mode.
- The bundle.js is no longer being called twice